### PR TITLE
Feat: MainActivity의 뒤로가기로직 및 카테고리 버튼 수정

### DIFF
--- a/app/src/main/java/net/developia/livartc/MainActivity.kt
+++ b/app/src/main/java/net/developia/livartc/MainActivity.kt
@@ -3,6 +3,7 @@ package net.developia.livartc
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
 import net.developia.livartc.databinding.ActivityMainBinding
 import net.developia.livartc.main.CartFragment
 import net.developia.livartc.main.CollectionsFragment

--- a/app/src/main/java/net/developia/livartc/MainActivity.kt
+++ b/app/src/main/java/net/developia/livartc/MainActivity.kt
@@ -26,6 +26,21 @@ class MainActivity : AppCompatActivity() {
         if (savedInstanceState == null)  binding.bottomNavigationView.selectedItemId = R.id.fragment_home
     }
 
+    override fun onBackPressed() {
+
+        when (supportFragmentManager.findFragmentById(R.id.main_container)) {
+            is CollectionsFragment, is CartFragment, is MyPageFragment -> {
+                // Replace with HomeFragment when pressing back from other fragments
+                binding.bottomNavigationView.selectedItemId = R.id.fragment_home
+            }
+            is HomeFragment -> {
+                // If the current fragment is HomeFragment, perform default back behavior
+                super.onBackPressed()
+            }
+            else -> super.onBackPressed()
+        }
+    }
+
     private fun setBottomNavigationView() {
         binding.bottomNavigationView.setOnItemSelectedListener {item ->
             when(item.itemId) {

--- a/app/src/main/java/net/developia/livartc/main/HomeFragment.kt
+++ b/app/src/main/java/net/developia/livartc/main/HomeFragment.kt
@@ -67,13 +67,13 @@ class HomeFragment : Fragment() {
         getAllBestProduct()
 
         // 카테고리 버튼 눌렀을 때 카테고리 Fragment 이동
-        binding.categoryBtn.setOnClickListener {
-            parentFragmentManager.beginTransaction().apply {
-                replace(R.id.main_container, CategoryFragment())
-                addToBackStack(null)
-                commit()
-            }
-        }
+//        binding.categoryBtn.setOnClickListener {
+//            parentFragmentManager.beginTransaction().apply {
+//                replace(R.id.main_container, CategoryFragment())
+//                addToBackStack(null)
+//                commit()
+//            }
+//        }
     }
 
     // 메인 배너 관련

--- a/app/src/main/java/net/developia/livartc/main/HomeFragment.kt
+++ b/app/src/main/java/net/developia/livartc/main/HomeFragment.kt
@@ -33,7 +33,7 @@ import retrofit2.Response
  * Date: 2024-01-22
  * Time: 오후 3:00
  */
-class HomeFragment : Fragment() {
+class HomeFragment : Fragment(), View.OnClickListener {
     lateinit var binding: FragmentHomeBinding
     private var currentPage = 0
     lateinit var bestList: List<Product>
@@ -74,6 +74,22 @@ class HomeFragment : Fragment() {
 //                commit()
 //            }
 //        }
+        binding.categoryBed.setOnClickListener(this)
+        binding.categoryDesk.setOnClickListener(this)
+        binding.categoryChair.setOnClickListener(this)
+        binding.categoryCabinet.setOnClickListener(this)
+        binding.categoryDeco.setOnClickListener(this)
+    }
+
+    //카테고리별 이동
+    override fun onClick(v: View?) {
+        when(v?.id) {
+            R.id.category_bed -> (activity as MainActivity).startProductActivity("침대")
+            R.id.category_desk -> (activity as MainActivity).startProductActivity("데스크")
+            R.id.category_chair -> (activity as MainActivity).startProductActivity("의자")
+            R.id.category_cabinet -> (activity as MainActivity).startProductActivity("수납장")
+            R.id.category_deco -> (activity as MainActivity).startProductActivity("홈데코")
+        }
     }
 
     // 메인 배너 관련

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -105,7 +105,7 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="0dp"
-                        android:text="상"
+                        android:text="데스크"
                         android:layout_weight="1"
                         android:layout_gravity="center"/>
                 </LinearLayout>
@@ -143,7 +143,7 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="0dp"
-                        android:text="장식"
+                        android:text="홈데코"
                         android:layout_weight="1"
                         android:layout_gravity="center"/>
                 </LinearLayout>
@@ -162,7 +162,7 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="0dp"
-                        android:text="수납"
+                        android:text="수납장"
                         android:layout_weight="1"
                         android:layout_gravity="center"/>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -63,12 +63,6 @@
                             android:layout_width="0dp"
                             android:layout_height="0dp"
                             android:layout_weight="1" />
-                        <ImageView
-                            android:id="@+id/category_move"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginEnd="10dp"
-                            android:src="@drawable/ic_next" />
             </LinearLayout>
             <LinearLayout
                 android:id="@+id/category_kind_box"


### PR DESCRIPTION
## ✨ 과제 내용
- #21 
- MainActivity에서 HomeFramgent를 제외하고 뒤로가기했을때 HomeFragment로 이동하게끔 변경
- 카테고리 화살표버튼을 없애고 그림버튼을 눌렀을때 해당 카테고리명 데이터를 가지고 조회로 넘어가게끔 설정

## 📸 스크린샷
![photo](https://github.com/livarter/android/assets/117807082/39093e35-670c-4c11-ae6e-d0326b69f1ec)
![photo01](https://github.com/livarter/android/assets/117807082/e36821d4-9515-4125-83bb-389c902b2558)


## 📚 참고사항
- HomeFragment에서 뒤로가기를 할때 앱이 꺼지도록 설정, 또한 뒤로가기 2번을해야 앱이 꺼지도록 설정할 예정



